### PR TITLE
ci: Upgrade to use checkout@v3 action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     # Run npm build and check that the dist/ folder is up to date.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         run: |
           npm install
@@ -30,7 +30,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run firebuild-action
         id: firebuild
         uses: ./
@@ -66,7 +66,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run firebuild action
         uses: ./
         id: output
@@ -85,7 +85,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           echo "RAND=$RANDOM" >> $GITHUB_ENV
       - name: Run firebuild action
@@ -106,7 +106,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           echo "RAND=$RANDOM" >> $GITHUB_ENV
       - name: Run firebuild action
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: apt update
       - name: Run firebuild-action
         uses: ./
@@ -137,7 +137,7 @@ jobs:
       matrix:
         save: [true, false]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run firebuild-action
         uses: ./
         with:


### PR DESCRIPTION
This gets rid of the warning about node 12 actions being deprecated.