### PR TITLE
Accept license on timeout after retrying fewer times

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -94560,7 +94560,7 @@ const ppaKey = "" +
     "6tC+\\n" +
     "=4Qt3\\n" +
     "-----END PGP PUBLIC KEY BLOCK-----\\n";
-async function fetchWithRetry(url, init, retries = 60, timeoutMs = 2000, backoffMs = 1500) {
+async function fetchWithRetry(url, init, retries = 4, timeoutMs = 2000, backoffMs = 3000) {
     let attempt = 0;
     let lastError;
     while (attempt <= retries) {

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -94633,7 +94633,9 @@ async function installFirebuildLinux() {
     }
     catch (err) {
         core.info(`License check timed out after retries: ${err}`);
-        acceptLicense = false;
+        // GitHub's network can be flaky, so in case of timeout, do not block the workflow
+        // and accept the license by default
+        acceptLicense = true;
     }
     if (acceptLicense) {
         await execBashSudo("sh -c 'echo debconf firebuild/license-accepted select true | debconf-set-selections'");

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -39,7 +39,7 @@ const ppaKey = "" +
 "=4Qt3\\n" +
 "-----END PGP PUBLIC KEY BLOCK-----\\n";
 
-async function fetchWithRetry(url: string, init?: any, retries = 60, timeoutMs = 2000, backoffMs = 1500) {
+async function fetchWithRetry(url: string, init?: any, retries = 4, timeoutMs = 2000, backoffMs = 3000) {
   let attempt = 0;
   let lastError: unknown;
   while (attempt <= retries) {

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -120,7 +120,9 @@ async function installFirebuildLinux() : Promise<void> {
     acceptLicense = resp.ok;
   } catch (err) {
     core.info(`License check timed out after retries: ${err}`);
-    acceptLicense = false;
+    // GitHub's network can be flaky, so in case of timeout, do not block the workflow
+    // and accept the license by default
+    acceptLicense = true;
   }
   if (acceptLicense) {
     await execBashSudo("sh -c 'echo debconf firebuild/license-accepted select true | debconf-set-selections'");


### PR DESCRIPTION
This helps with unreliable networking of some GitHub hosted runners.